### PR TITLE
Fix: Resolve issue where prediction gets stuck

### DIFF
--- a/image_classification.py
+++ b/image_classification.py
@@ -15,7 +15,7 @@ def model_predict(img_path, model):
     # x = np.true_divide(x, 255)
     x = np.expand_dims(x, axis=0)
     # preds = model.predict(x)
-    preds = model(x)
+    preds = model.predict(x)
     return preds
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow
+tensorflow==2.9.0
 flask
 gunicorn
 pillow


### PR DESCRIPTION
The application was getting stuck during the image prediction phase. This was likely due to a combination of unspecified TensorFlow version and the use of a direct model call `model(x)` instead of `model.predict(x)`.

Changes made:
- Specified TensorFlow version as 2.9.0 in requirements.txt for better compatibility.
- Changed the prediction call in `image_classification.py` to use `model.predict(x)`.

The application now successfully processes image uploads and returns predictions. I also ensured the `static/uploads` directory exists, which might have been a contributing factor if any part of the application or its dependencies implicitly relied on it.